### PR TITLE
Fix insistent shmem_kernel_file_setup call in big_key.c.

### DIFF
--- a/security/keys/big_key.c
+++ b/security/keys/big_key.c
@@ -245,7 +245,7 @@ int big_key_preparse(struct key_preparsed_payload *prep)
 			goto err_enckey;
 
 		/* save aligned data to file */
-		file = shmem_kernel_file_setup("", enclen, 0);
+		file = shmem_kernel_file_setup("", enclen, 0, 0);
 		if (IS_ERR(file)) {
 			ret = PTR_ERR(file);
 			goto err_enckey;


### PR DESCRIPTION
This fixes a compilation issue.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>